### PR TITLE
Remove test limit - download all S&P 500 companies

### DIFF
--- a/scripts/download_sp500_10k.py
+++ b/scripts/download_sp500_10k.py
@@ -97,18 +97,14 @@ def get_company_filings(cik, ticker, company_name):
         print(f"Error processing {ticker}: {e}")
 
 def main():
-    # Test with just a few major companies
-    test_companies = [
-        {'Symbol': 'AAPL', 'Security': 'Apple Inc.', 'CIK': 320193},
-        {'Symbol': 'MSFT', 'Security': 'Microsoft Corp', 'CIK': 789019},
-        {'Symbol': 'GOOGL', 'Security': 'Alphabet Inc.', 'CIK': 1652044},
-        {'Symbol': 'AMZN', 'Security': 'Amazon.com Inc.', 'CIK': 1018724},
-        {'Symbol': 'META', 'Security': 'Meta Platforms Inc.', 'CIK': 1326801}
-    ]
+    # Get all S&P 500 companies
+    print("Getting S&P 500 companies list...")
+    companies = get_sp500_companies()
     
-    # Download filings for test companies
-    for idx, company in enumerate(test_companies, 1):
-        print(f"\nProcessing {idx}/{len(test_companies)}: {company['Symbol']} - {company['Security']}")
+    # Download filings for all companies
+    total = len(companies)
+    for idx, (_, company) in enumerate(companies.iterrows(), 1):
+        print(f"\nProcessing {idx}/{total}: {company['Symbol']} - {company['Security']}")
         get_company_filings(company['CIK'], company['Symbol'], company['Security'])
         # Sleep between companies to respect SEC rate limits
         time.sleep(0.1)


### PR DESCRIPTION
This PR updates the download script to process all S&P 500 companies instead of just the test set.

Changes:
- Removed test company list
- Now downloads all S&P 500 companies
- Uses pandas to get company list from Wikipedia

The script will:
1. Get the full S&P 500 company list
2. Download 10-K filings for each company
3. Save HTML and XBRL data
4. Convert HTML to PDF (optional)

All files will be stored in the data directory, which is now included in git.